### PR TITLE
Fix typos

### DIFF
--- a/R/licensing.R
+++ b/R/licensing.R
@@ -7,7 +7,6 @@
 #' licensing_md()
 licensing_md <- function() {
   "## Licensing
-  Copyright xx xx\\
   Copyright 2023-2024 Province of Alberta\\
   
   The documentation is released under the

--- a/R/utils.R
+++ b/R/utils.R
@@ -4,7 +4,7 @@ msg <- function(...) {
   }
 }
 
-#' List all bbousite packages
+#' List all bbousuite packages
 #'
 #' Inspired by `tidyverse::tidyverse_packages()`.
 #' @param include_self Include bbousuite in the list?

--- a/README.Rmd
+++ b/README.Rmd
@@ -39,7 +39,7 @@ remotes::install_github("poissonconsulting/bbousuite")
 
 ## Load
 
-To load `bbousite`
+To load `bbousuite`
 
 ```{r}
 library(bbousuite)
@@ -70,7 +70,7 @@ If you would like to contribute to the package, please see our
 
 ## Code of Conduct
 
-Please note that the ssdtools project is released with a [Contributor Code of Conduct](https://contributor-covenant.org/version/2/1/CODE_OF_CONDUCT.html). By contributing to this project, you agree to abide by its terms.
+Please note that the bbou project is released with a [Contributor Code of Conduct](https://contributor-covenant.org/version/2/1/CODE_OF_CONDUCT.html). By contributing to this project, you agree to abide by its terms.
 
 ```{r, results = "asis", echo = FALSE}
 cat(licensing_md())

--- a/man/bbousuite_packages.Rd
+++ b/man/bbousuite_packages.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/utils.R
 \name{bbousuite_packages}
 \alias{bbousuite_packages}
-\title{List all bbousite packages}
+\title{List all bbousuite packages}
 \usage{
 bbousuite_packages(include_self = TRUE)
 }


### PR DESCRIPTION
I found a few typos when using this packages as inspiration for `bisonpicsuite`.
Also removed a line from the licensing statement that seemed redundant – check this.